### PR TITLE
Adjust error handling to scope rescue to API calls only

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -18,22 +18,22 @@ module OpenTelemetry
             tracer.in_span("chat #{model_id}", attributes: attributes, kind: OpenTelemetry::Trace::SpanKind::CLIENT) do |span|
               begin
                 result = super
-
-                if @messages.last
-                  response = @messages.last
-                  span.set_attribute("gen_ai.response.model", response.model_id) if response.model_id
-                  span.set_attribute("gen_ai.usage.input_tokens", response.input_tokens) if response.input_tokens
-                  span.set_attribute("gen_ai.usage.output_tokens", response.output_tokens) if response.output_tokens
-                  span.set_attribute("gen_ai.request.temperature", @temperature) if @temperature
-                end
-
-                result
               rescue => e
                 span.record_exception(e)
                 span.status = OpenTelemetry::Trace::Status.error(e.message)
                 span.set_attribute("error.type", e.class.name)
                 raise
               end
+
+              if @messages.last
+                response = @messages.last
+                span.set_attribute("gen_ai.response.model", response.model_id) if response.model_id
+                span.set_attribute("gen_ai.usage.input_tokens", response.input_tokens) if response.input_tokens
+                span.set_attribute("gen_ai.usage.output_tokens", response.output_tokens) if response.output_tokens
+                span.set_attribute("gen_ai.request.temperature", @temperature) if @temperature
+              end
+
+              result
             end
           rescue StandardError => e
             OpenTelemetry.handle_error(exception: e)


### PR DESCRIPTION
The inner rescue now wraps only the super call, so instrumentation bugs don't get misrecorded as API errors on the span.