### PR TITLE
Align chat ask signature with RubyLLM interface

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -5,7 +5,7 @@ module OpenTelemetry
     module RubyLLM
       module Patches
         module Chat
-          def ask(message, &block)
+          def ask(message = nil, with: nil, &)
             provider = @model&.provider || "unknown"
             model_id = @model&.id || "unknown"
 


### PR DESCRIPTION
## What changed

Updated the instrumentation patch for `Chat#ask` to match the current RubyLLM interface:

- changed the method signature from `ask(message, &block)`
- to `ask(message = nil, with: nil, &)`

## Why

RubyLLM's `ask` interface now accepts optional arguments/keywords, including `with:`. The previous patch signature crash with valid calls before they reached the original implementation, causing compatibility
issues in instrumented chats.

This change keeps the instrumentation wrapper aligned with the upstream API while preserving the existing `super` call behavior.