### PR TITLE
Add instrumentation for RubyLLM::Embedding.embed

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
@@ -15,7 +15,9 @@ module OpenTelemetry
 
         install do |_config|
           require_relative "patches/chat"
+          require_relative "patches/embedding"
           ::RubyLLM::Chat.prepend(Patches::Chat)
+          ::RubyLLM::Embedding.singleton_class.prepend(Patches::Embedding)
         end
       end
     end

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/embedding.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/embedding.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module OpenTelemetry
+  module Instrumentation
+    module RubyLLM
+      module Patches
+        module Embedding
+          def embed(text, model: nil, provider: nil, assume_model_exists: false, context: nil, dimensions: nil)
+            config = context&.config || ::RubyLLM.config
+            resolved_model = model || config.default_embedding_model
+            model_obj, _provider_instance = ::RubyLLM::Models.resolve(
+              resolved_model, provider: provider, assume_exists: assume_model_exists, config: config
+            )
+            model_id = model_obj.id
+            provider_name = model_obj.provider || "unknown"
+
+            attributes = {
+              "gen_ai.operation.name" => "embeddings",
+              "gen_ai.provider.name" => provider_name,
+              "gen_ai.request.model" => model_id
+            }
+
+            tracer.in_span("embeddings #{model_id}", attributes: attributes, kind: OpenTelemetry::Trace::SpanKind::CLIENT) do |span|
+              begin
+                result = super
+              rescue => e
+                span.record_exception(e)
+                span.status = OpenTelemetry::Trace::Status.error(e.message)
+                span.set_attribute("error.type", e.class.name)
+                raise
+              end
+
+              span.set_attribute("gen_ai.response.model", result.model) if result.model
+              span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens) if result.input_tokens&.positive?
+
+              if result.vectors.is_a?(Array)
+                first = result.vectors.first
+                vector = first.is_a?(Array) ? first : result.vectors
+                span.set_attribute("gen_ai.embeddings.dimension.count", vector.length) if vector.is_a?(Array)
+              end
+
+              result
+            end
+          rescue StandardError => e
+            OpenTelemetry.handle_error(exception: e)
+            super
+          end
+
+          private
+
+          def tracer
+            RubyLLM::Instrumentation.instance.tracer
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -332,6 +332,78 @@ class InstrumentationTest < Minitest::Test
     OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
   end
 
+  def test_creates_span_for_embedding
+    stub_request(:post, "https://api.openai.com/v1/embeddings")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          object: "list",
+          model: "text-embedding-3-small",
+          data: [
+            { object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }
+          ],
+          usage: { prompt_tokens: 8, total_tokens: 8 }
+        }.to_json
+      )
+
+    RubyLLM.embed("Hello, world!", model: "text-embedding-3-small")
+
+    spans = EXPORTER.finished_spans
+    assert_equal 1, spans.length
+
+    span = spans.first
+    assert_equal OpenTelemetry::Trace::SpanKind::CLIENT, span.kind
+    assert_equal "embeddings text-embedding-3-small", span.name
+    assert_equal "embeddings", span.attributes["gen_ai.operation.name"]
+    assert_equal "openai", span.attributes["gen_ai.provider.name"]
+    assert_equal "text-embedding-3-small", span.attributes["gen_ai.request.model"]
+    assert_equal "text-embedding-3-small", span.attributes["gen_ai.response.model"]
+    assert_equal 8, span.attributes["gen_ai.usage.input_tokens"]
+    assert_equal 3, span.attributes["gen_ai.embeddings.dimension.count"]
+  end
+
+  def test_records_error_on_embedding_api_failure
+    stub_request(:post, "https://api.openai.com/v1/embeddings")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    assert_raises do
+      RubyLLM.embed("Hello", model: "text-embedding-3-small")
+    end
+
+    spans = EXPORTER.finished_spans
+    span = spans.last
+
+    assert_equal "embeddings text-embedding-3-small", span.name
+    assert span.attributes["error.type"]
+    assert_equal OpenTelemetry::Trace::Status::ERROR, span.status.code
+  end
+
+  def test_embed_still_works_when_instrumentation_fails
+    stub_request(:post, "https://api.openai.com/v1/embeddings")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          object: "list",
+          model: "text-embedding-3-small",
+          data: [
+            { object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }
+          ],
+          usage: { prompt_tokens: 8, total_tokens: 8 }
+        }.to_json
+      )
+
+    mod = OpenTelemetry::Instrumentation::RubyLLM::Patches::Embedding
+    original_tracer = mod.instance_method(:tracer)
+    mod.define_method(:tracer) { raise StandardError, "instrumentation bug" }
+
+    result = RubyLLM.embed("Hello, world!", model: "text-embedding-3-small")
+    assert_equal [0.1, 0.2, 0.3], result.vectors
+  ensure
+    mod.define_method(:tracer, original_tracer)
+  end
+
   def test_captures_content_when_enabled_via_env_var
     ENV["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
 


### PR DESCRIPTION
Instrument the embeddings endpoint following the OpenTelemetry GenAI semantic conventions for embedding spans. The patch is applied via singleton_class.prepend on RubyLLM::Embedding, wrapping the class-level embed method with a CLIENT span.

Span attributes:
- gen_ai.operation.name: "embeddings"
- gen_ai.provider.name: resolved provider (e.g. "openai")
- gen_ai.request.model / gen_ai.response.model: model identifiers
- gen_ai.usage.input_tokens: token count from the response
- gen_ai.embeddings.dimension.count: length of the embedding vector
- error.type: exception class on API failures

Error handling follows the same pattern as Chat instrumentation: API errors are recorded on the span and re-raised, while instrumentation failures are swallowed to avoid breaking the underlying embed call.

Tests cover span creation with all attributes, error recording on API failure, and resilience when instrumentation itself fails.

<img width="609" height="149" alt="Screenshot 2026-03-26 at 12 41 36" src="https://github.com/user-attachments/assets/ea86f1c5-6bf6-4fc5-8d82-e5c7a4984811" />
