### PR TITLE
Relax Ruby version requirement from 3.2.0 to 3.1.3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
           - '3.4'
           - '3.3'
           - '3.2'
+          - '3.1'
 
     steps:
       - uses: actions/checkout@v4

--- a/opentelemetry-instrumentation-ruby_llm.gemspec
+++ b/opentelemetry-instrumentation-ruby_llm.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.description = "Adds OpenTelemetry tracing to RubyLLM chat operations"
   spec.homepage    = "https://github.com/thoughtbot/opentelemetry-instrumentation-ruby_llm"
 
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 3.1.3"
 
   spec.metadata["homepage_uri"] = spec.homepage
 


### PR DESCRIPTION
## Summary

Since [ruby_llm](https://rubygems.org/gems/ruby_llm/versions/1.14.1) supports Ruby >= 3.1.3, this relaxes the minimum Ruby version to 3.1.3 to match. No Ruby 3.2-specific code was identified, and all specs continue to pass.

- Updates `required_ruby_version` from `>= 3.2.0` to `>= 3.1.3`

Closes #18