### PR TITLE
Remove outer rescue blocks that caused duplicate RubyLLM calls

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
@@ -15,7 +15,9 @@ module OpenTelemetry
 
         install do |_config|
           require_relative "patches/chat"
+          require_relative "patches/embedding"
           ::RubyLLM::Chat.prepend(Patches::Chat)
+          ::RubyLLM::Embedding.singleton_class.prepend(Patches::Embedding)
         end
       end
     end

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -47,9 +47,6 @@ module OpenTelemetry
 
               result
             end
-          rescue StandardError => e
-            OpenTelemetry.handle_error(exception: e)
-            super
           end
 
           def execute_tool(tool_call)
@@ -66,9 +63,6 @@ module OpenTelemetry
               span.set_attribute("gen_ai.tool.call.result", result_str[0..500])
               result
             end
-          rescue StandardError => e
-            OpenTelemetry.handle_error(exception: e)
-            super
           end
 
           private

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/embedding.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/embedding.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+module OpenTelemetry
+  module Instrumentation
+    module RubyLLM
+      module Patches
+        module Embedding
+          def embed(text, model: nil, provider: nil, assume_model_exists: false, context: nil, dimensions: nil)
+            config = context&.config || ::RubyLLM.config
+            resolved_model = model || config.default_embedding_model
+            model_obj, _provider_instance = ::RubyLLM::Models.resolve(
+              resolved_model, provider: provider, assume_exists: assume_model_exists, config: config
+            )
+            model_id = model_obj.id
+            provider_name = model_obj.provider || "unknown"
+
+            attributes = {
+              "gen_ai.operation.name" => "embeddings",
+              "gen_ai.provider.name" => provider_name,
+              "gen_ai.request.model" => model_id
+            }
+
+            tracer.in_span("embeddings #{model_id}", attributes: attributes, kind: OpenTelemetry::Trace::SpanKind::CLIENT) do |span|
+              begin
+                result = super
+              rescue => e
+                span.record_exception(e)
+                span.status = OpenTelemetry::Trace::Status.error(e.message)
+                span.set_attribute("error.type", e.class.name)
+                raise
+              end
+
+              span.set_attribute("gen_ai.response.model", result.model) if result.model
+              span.set_attribute("gen_ai.usage.input_tokens", result.input_tokens) if result.input_tokens&.positive?
+
+              if result.vectors.is_a?(Array)
+                first = result.vectors.first
+                vector = first.is_a?(Array) ? first : result.vectors
+                span.set_attribute("gen_ai.embeddings.dimension.count", vector.length) if vector.is_a?(Array)
+              end
+
+              result
+            end
+          rescue StandardError => e
+            OpenTelemetry.handle_error(exception: e)
+            super
+          end
+
+          private
+
+          def tracer
+            RubyLLM::Instrumentation.instance.tracer
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/embedding.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/embedding.rb
@@ -41,9 +41,6 @@ module OpenTelemetry
 
               result
             end
-          rescue StandardError => e
-            OpenTelemetry.handle_error(exception: e)
-            super
           end
 
           private

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -332,6 +332,78 @@ class InstrumentationTest < Minitest::Test
     OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
   end
 
+  def test_creates_span_for_embedding
+    stub_request(:post, "https://api.openai.com/v1/embeddings")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          object: "list",
+          model: "text-embedding-3-small",
+          data: [
+            { object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }
+          ],
+          usage: { prompt_tokens: 8, total_tokens: 8 }
+        }.to_json
+      )
+
+    RubyLLM.embed("Hello, world!", model: "text-embedding-3-small")
+
+    spans = EXPORTER.finished_spans
+    assert_equal 1, spans.length
+
+    span = spans.first
+    assert_equal OpenTelemetry::Trace::SpanKind::CLIENT, span.kind
+    assert_equal "embeddings text-embedding-3-small", span.name
+    assert_equal "embeddings", span.attributes["gen_ai.operation.name"]
+    assert_equal "openai", span.attributes["gen_ai.provider.name"]
+    assert_equal "text-embedding-3-small", span.attributes["gen_ai.request.model"]
+    assert_equal "text-embedding-3-small", span.attributes["gen_ai.response.model"]
+    assert_equal 8, span.attributes["gen_ai.usage.input_tokens"]
+    assert_equal 3, span.attributes["gen_ai.embeddings.dimension.count"]
+  end
+
+  def test_records_error_on_embedding_api_failure
+    stub_request(:post, "https://api.openai.com/v1/embeddings")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    assert_raises do
+      RubyLLM.embed("Hello", model: "text-embedding-3-small")
+    end
+
+    spans = EXPORTER.finished_spans
+    span = spans.last
+
+    assert_equal "embeddings text-embedding-3-small", span.name
+    assert span.attributes["error.type"]
+    assert_equal OpenTelemetry::Trace::Status::ERROR, span.status.code
+  end
+
+  def test_embed_still_works_when_instrumentation_fails
+    stub_request(:post, "https://api.openai.com/v1/embeddings")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          object: "list",
+          model: "text-embedding-3-small",
+          data: [
+            { object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }
+          ],
+          usage: { prompt_tokens: 8, total_tokens: 8 }
+        }.to_json
+      )
+
+    mod = OpenTelemetry::Instrumentation::RubyLLM::Patches::Embedding
+    original_tracer = mod.instance_method(:tracer)
+    mod.define_method(:tracer) { raise StandardError, "instrumentation bug" }
+
+    result = RubyLLM.embed("Hello, world!", model: "text-embedding-3-small")
+    assert_equal [0.1, 0.2, 0.3], result.vectors
+  ensure
+    mod.define_method(:tracer, original_tracer)
+  end
+
   def test_captures_content_when_enabled_via_env_var
     ENV["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
 

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -67,31 +67,6 @@ class InstrumentationTest < Minitest::Test
     assert_equal OpenTelemetry::Trace::Status::ERROR, span.status.code
   end
 
-  def test_complete_still_works_when_instrumentation_fails
-    stub_request(:post, "https://api.openai.com/v1/chat/completions")
-      .to_return(
-        status: 200,
-        headers: { "Content-Type" => "application/json" },
-        body: {
-          id: "chatcmpl-123",
-          object: "chat.completion",
-          model: "gpt-4o-mini",
-          choices: [{
-            index: 0,
-            message: { role: "assistant", content: "Hello!" },
-            finish_reason: "stop"
-          }],
-          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
-        }.to_json
-      )
-
-    chat = RubyLLM.chat(model: "gpt-4o-mini")
-    chat.define_singleton_method(:tracer) { raise StandardError, "instrumentation bug" }
-
-    response = chat.ask("Hi")
-    assert_equal "Hello!", response.content
-  end
-
   def test_instruments_complete_called_directly
     stub_request(:post, "https://api.openai.com/v1/chat/completions")
       .to_return(
@@ -198,68 +173,6 @@ class InstrumentationTest < Minitest::Test
     assert_equal "4", tool_span.attributes["gen_ai.tool.call.result"]
     assert_equal "call_abc123", tool_span.attributes["gen_ai.tool.call.id"]
     assert_equal "function", tool_span.attributes["gen_ai.tool.type"]
-  end
-
-  def test_execute_tool_still_works_when_instrumentation_fails
-    calculator = Class.new(RubyLLM::Tool) do
-      def self.name = "calculator"
-      description "Performs math"
-      param :expression, type: "string", desc: "Math expression"
-
-      def execute(expression:)
-        eval(expression).to_s
-      end
-    end
-
-    stub_request(:post, "https://api.openai.com/v1/chat/completions")
-      .to_return(
-        {
-          status: 200,
-          headers: { "Content-Type" => "application/json" },
-          body: {
-            id: "chatcmpl-123",
-            object: "chat.completion",
-            model: "gpt-4o-mini",
-            choices: [{
-              index: 0,
-              message: {
-                role: "assistant",
-                content: nil,
-                tool_calls: [{
-                  id: "call_abc123",
-                  type: "function",
-                  function: { name: "calculator", arguments: '{"expression":"2+2"}' }
-                }]
-              },
-              finish_reason: "tool_calls"
-            }],
-            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
-          }.to_json
-        },
-        {
-          status: 200,
-          headers: { "Content-Type" => "application/json" },
-          body: {
-            id: "chatcmpl-456",
-            object: "chat.completion",
-            model: "gpt-4o-mini",
-            choices: [{
-              index: 0,
-              message: { role: "assistant", content: "The answer is 4" },
-              finish_reason: "stop"
-            }],
-            usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 }
-          }.to_json
-        }
-      )
-
-    chat = RubyLLM.chat(model: "gpt-4o-mini")
-    chat.with_tool(calculator)
-
-    chat.define_singleton_method(:tracer) { raise StandardError, "instrumentation bug" }
-
-    response = chat.ask("What is 2+2?")
-    assert_equal "The answer is 4", response.content
   end
 
   def test_does_not_capture_content_by_default
@@ -377,31 +290,6 @@ class InstrumentationTest < Minitest::Test
     assert_equal "embeddings text-embedding-3-small", span.name
     assert span.attributes["error.type"]
     assert_equal OpenTelemetry::Trace::Status::ERROR, span.status.code
-  end
-
-  def test_embed_still_works_when_instrumentation_fails
-    stub_request(:post, "https://api.openai.com/v1/embeddings")
-      .to_return(
-        status: 200,
-        headers: { "Content-Type" => "application/json" },
-        body: {
-          object: "list",
-          model: "text-embedding-3-small",
-          data: [
-            { object: "embedding", index: 0, embedding: [0.1, 0.2, 0.3] }
-          ],
-          usage: { prompt_tokens: 8, total_tokens: 8 }
-        }.to_json
-      )
-
-    mod = OpenTelemetry::Instrumentation::RubyLLM::Patches::Embedding
-    original_tracer = mod.instance_method(:tracer)
-    mod.define_method(:tracer) { raise StandardError, "instrumentation bug" }
-
-    result = RubyLLM.embed("Hello, world!", model: "text-embedding-3-small")
-    assert_equal [0.1, 0.2, 0.3], result.vectors
-  ensure
-    mod.define_method(:tracer, original_tracer)
   end
 
   def test_captures_content_when_enabled_via_env_var


### PR DESCRIPTION
The outer `rescue StandardError` blocks in `complete`, `execute_tool`,
and `embed` were catching errors from instrumentation, logging them
via `OpenTelemetry.handle_error`, and then calling `super` — which
re-executed the original RubyLLM method, resulting in duplicate API
calls to the LLM provider.

This is safe to remove because `Tracer#in_span` already handles
exceptions internally by recording them and re-raising:
https://github.com/open-telemetry/opentelemetry-ruby/blob/0b94ef6086facf3c7ad584485bb3825b0ab90e39/api/lib/opentelemetry/trace/tracer.rb#L34-L44

This pattern is also not used in other opentelemetry-ruby-contrib
instrumentation libraries:
https://github.com/search?q=repo%3Aopen-telemetry%2Fopentelemetry-ruby-contrib+handle_error&type=code

The inner `begin/rescue` blocks inside each span are preserved as they
add the `error.type` attribute per GenAI semantic conventions.