### PR TITLE
fix: set gen_ai.operation.name for tool spans to "execute_tool"

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -58,6 +58,7 @@ module OpenTelemetry
 
           def execute_tool(tool_call)
             attributes = {
+              "gen_ai.operation.name" => "execute_tool",
               "gen_ai.tool.name" => tool_call.name,
               "gen_ai.tool.call.id" => tool_call.id,
               "gen_ai.tool.call.arguments" => tool_call.arguments.to_json,

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -168,6 +168,7 @@ class InstrumentationTest < Minitest::Test
     tool_span = tool_spans.first
     assert_equal OpenTelemetry::Trace::SpanKind::INTERNAL, tool_span.kind
     assert_equal "execute_tool calculator", tool_span.name
+    assert_equal "execute_tool", tool_span.attributes["gen_ai.operation.name"]
     assert_equal "calculator", tool_span.attributes["gen_ai.tool.name"]
     assert_equal '{"expression":"2+2"}', tool_span.attributes["gen_ai.tool.call.arguments"]
     assert_equal "4", tool_span.attributes["gen_ai.tool.call.result"]


### PR DESCRIPTION
From https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span:

> `gen_ai.operation.name` SHOULD be `execute_tool`.

We have found that DataDog requires this tag to display tool spans in the UI properly.