### PR TITLE
fix: require ruby_llm >= 1.8.0 via OTel `compatible` block

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
@@ -4,6 +4,8 @@ module OpenTelemetry
   module Instrumentation
     module RubyLLM
       class Instrumentation < OpenTelemetry::Instrumentation::Base
+        MINIMUM_RUBY_LLM_VERSION = "1.8.0"
+
         instrumentation_name "OpenTelemetry::Instrumentation::RubyLLM"
         instrumentation_version VERSION
 
@@ -11,6 +13,22 @@ module OpenTelemetry
 
         present do
           defined?(::RubyLLM)
+        end
+
+        compatible do
+          # The embedding patch calls `RubyLLM::Models.resolve` (class-method delegation added in 1.8.0);
+          # Anything older than 1.8.0 would NoMethodError / NameError at install or first use.
+          compatible = Gem::Version.new(::RubyLLM::VERSION) >= Gem::Version.new(MINIMUM_RUBY_LLM_VERSION)
+
+          unless compatible
+            OpenTelemetry.logger.warn(
+              "[OpenTelemetry::Instrumentation::RubyLLM] ruby_llm " \
+              "#{::RubyLLM::VERSION} is below the required minimum " \
+              "#{MINIMUM_RUBY_LLM_VERSION}; instrumentation will not be installed."
+            )
+          end
+
+          compatible
         end
 
         install do |_config|

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -9,6 +9,27 @@ class InstrumentationTest < Minitest::Test
     end
   end
 
+  def test_compatible_is_true_for_current_ruby_llm_version
+    instrumentation = OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance
+    assert_equal true, instrumentation.compatible?
+  end
+
+  def test_compatible_is_false_when_ruby_llm_below_minimum
+    original_version = ::RubyLLM::VERSION
+    ::RubyLLM.send(:remove_const, :VERSION)
+    ::RubyLLM.const_set(:VERSION, "1.7.99")
+
+    instrumentation = OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance
+    assert_equal false, instrumentation.compatible?
+  ensure
+    ::RubyLLM.send(:remove_const, :VERSION)
+    ::RubyLLM.const_set(:VERSION, original_version)
+  end
+
+  def test_minimum_ruby_llm_version_is_pinned_at_1_8_0
+    assert_equal "1.8.0", OpenTelemetry::Instrumentation::RubyLLM::Instrumentation::MINIMUM_RUBY_LLM_VERSION
+  end
+
   def test_creates_span_with_attributes
     stub_request(:post, "https://api.openai.com/v1/chat/completions")
       .to_return(


### PR DESCRIPTION
Make the requirement explicit via the standard OTel instrumentation pattern: a `compatible` block that returns false when the loaded `ruby_llm` version is below the pin (mirrors what httpx, http, http_client do in `opentelemetry-ruby-contrib`).

When the block returns false, `OpenTelemetry::Instrumentation::Base` silently skips installing the instrumentation — no raise, no patch application — so apps on older `ruby_llm` continue to function without the OTel traces (and without a hard crash).