### PR TITLE
Capture RubyLLM::Content and RubyLLM::Content::Raw in message spans

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
@@ -32,6 +32,7 @@ module OpenTelemetry
         end
 
         install do |_config|
+          require_relative "message_formatter"
           require_relative "patches/chat"
           require_relative "patches/embedding"
           ::RubyLLM::Chat.prepend(Patches::Chat)

--- a/lib/opentelemetry/instrumentation/ruby_llm/message_formatter.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/message_formatter.rb
@@ -50,10 +50,10 @@ module OpenTelemetry
           # `RubyLLM::Content::Raw` was added in ruby_llm 1.9.0, so guard the
           # constant rather than referencing it in a `case`/`when`.
           if defined?(::RubyLLM::Content::Raw) && content.is_a?(::RubyLLM::Content::Raw)
-            # A `GenericPart` (custom `type`) so the provider-specific payload
-            # is preserved verbatim without clashing with the standard part
-            # types. The raw value is passed through as-is, not re-encoded.
-            [{ type: "raw", content: content.value }]
+            # Serialize the provider-specific payload to JSON so consumers
+            # (e.g. Langfuse) render it as readable text rather than
+            # `[object Object]`.
+            [{ type: "raw", content: content.value.to_json }]
           elsif content.is_a?(::RubyLLM::Content)
             parts = []
             parts << { type: "text", content: content.text } unless content.text.nil?

--- a/lib/opentelemetry/instrumentation/ruby_llm/message_formatter.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/message_formatter.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module OpenTelemetry
+  module Instrumentation
+    module RubyLLM
+      # Converts `RubyLLM` messages and content into the JSON shape defined by
+      # the GenAI semantic conventions for input/output messages and system
+      # instructions:
+      #
+      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-input-messages.json
+      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-output-messages.json
+      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-system-instructions.json
+      #
+      # Kept separate from the `RubyLLM::Chat` patch so the formatting logic
+      # does not pollute the patched class.
+      module MessageFormatter
+        def self.format_input_messages(messages)
+          messages.map { |m| format_message(m) }.to_json
+        end
+
+        def self.format_output_messages(messages)
+          messages.map { |m| format_message(m) }.to_json
+        end
+
+        def self.format_system_instructions(messages)
+          messages.flat_map { |m| format_content(m.content) }.to_json
+        end
+
+        private_class_method def self.format_message(message)
+          msg = { role: message.role.to_s, parts: [] }
+
+          if message.content
+            msg[:parts].concat(format_content(message.content))
+          end
+
+          if message.tool_calls&.any?
+            message.tool_calls.each_value do |tc|
+              msg[:parts] << { type: "tool_call", id: tc.id, name: tc.name, arguments: tc.arguments }
+            end
+          end
+
+          msg[:tool_call_id] = message.tool_call_id if message.tool_call_id
+
+          msg
+        end
+
+        # Maps a `RubyLLM::Content`/`RubyLLM::Content::Raw` onto an array of
+        # GenAI message parts.
+        private_class_method def self.format_content(content)
+          # `RubyLLM::Content::Raw` was added in ruby_llm 1.9.0, so guard the
+          # constant rather than referencing it in a `case`/`when`.
+          if defined?(::RubyLLM::Content::Raw) && content.is_a?(::RubyLLM::Content::Raw)
+            # A `GenericPart` (custom `type`) so the provider-specific payload
+            # is preserved verbatim without clashing with the standard part
+            # types. The raw value is passed through as-is, not re-encoded.
+            [{ type: "raw", content: content.value }]
+          elsif content.is_a?(::RubyLLM::Content)
+            parts = []
+            parts << { type: "text", content: content.text } unless content.text.nil?
+            content.attachments.each do |attachment|
+              parts << format_attachment(attachment)
+            end
+            parts
+          else
+            [{ type: "text", content: content.to_s }]
+          end
+        end
+
+        # Maps a `RubyLLM::Attachment` onto a GenAI message part.
+        private_class_method def self.format_attachment(attachment)
+          part = { modality: attachment_modality(attachment) }
+          part[:mime_type] = attachment.mime_type if attachment.mime_type
+
+          if attachment.url?
+            part[:type] = "uri"
+            part[:uri] = attachment.source.to_s
+          else
+            part[:type] = "blob"
+            part[:content] = attachment.source.to_s
+          end
+
+          part
+        end
+
+        # Maps a `RubyLLM::Attachment#type` onto a GenAI modality.
+        private_class_method def self.attachment_modality(attachment)
+          case attachment.type
+          when :image then "image"
+          when :video then "video"
+          when :audio then "audio"
+          else "document"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -55,11 +55,11 @@ module OpenTelemetry
                   input_messages = @messages[0..-2].reject { |m| m.role == :system }
 
                   unless system_messages.empty?
-                    span.set_attribute("gen_ai.system_instructions", format_system_instructions(system_messages))
+                    span.set_attribute("gen_ai.system_instructions", MessageFormatter.format_system_instructions(system_messages))
                   end
 
-                  span.set_attribute("gen_ai.input.messages", format_messages(input_messages))
-                  span.set_attribute("gen_ai.output.messages", format_messages([response]))
+                  span.set_attribute("gen_ai.input.messages", MessageFormatter.format_input_messages(input_messages))
+                  span.set_attribute("gen_ai.output.messages", MessageFormatter.format_output_messages([response]))
                 end
               end
 
@@ -104,32 +104,6 @@ module OpenTelemetry
             return env_value.to_s.strip.casecmp("true").zero? unless env_value.nil?
 
             RubyLLM::Instrumentation.instance.config[:capture_content]
-          end
-
-          def format_messages(messages)
-            messages.map { |m| format_message(m) }.to_json
-          end
-
-          def format_message(message)
-            msg = { role: message.role.to_s, parts: [] }
-
-            if message.content
-              msg[:parts] << { type: "text", content: message.content.to_s }
-            end
-
-            if message.tool_calls&.any?
-              message.tool_calls.each_value do |tc|
-                msg[:parts] << { type: "tool_call", id: tc.id, name: tc.name, arguments: tc.arguments }
-              end
-            end
-
-            msg[:tool_call_id] = message.tool_call_id if message.tool_call_id
-
-            msg
-          end
-
-          def format_system_instructions(system_messages)
-            system_messages.map { |m| { type: "text", content: m.content.to_s } }.to_json
           end
 
           def tracer

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -626,7 +626,7 @@ class InstrumentationTest < Minitest::Test
     span = EXPORTER.finished_spans.first
     input_messages = JSON.parse(span.attributes["gen_ai.input.messages"])
     assert_equal(
-      [{ "type" => "raw", "content" => [{ "type" => "text", "text" => "raw payload" }] }],
+      [{ "type" => "raw", "content" => [{ "type" => "text", "text" => "raw payload" }].to_json }],
       input_messages[0]["parts"]
     )
   ensure
@@ -664,7 +664,7 @@ class InstrumentationTest < Minitest::Test
     span = EXPORTER.finished_spans.first
     system_instructions = JSON.parse(span.attributes["gen_ai.system_instructions"])
     assert_equal(
-      [{ "type" => "raw", "content" => [{ "type" => "text", "text" => "You are helpful" }] }],
+      [{ "type" => "raw", "content" => [{ "type" => "text", "text" => "You are helpful" }].to_json }],
       system_instructions
     )
   ensure

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -552,6 +552,125 @@ class InstrumentationTest < Minitest::Test
     assert_equal "Hello!", response.content
   end
 
+  def test_captures_ruby_llm_content_with_attachments
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          id: "chatcmpl-123",
+          object: "chat.completion",
+          model: "gpt-4o-mini",
+          choices: [{
+            index: 0,
+            message: { role: "assistant", content: "A cat." },
+            finish_reason: "stop"
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+        }.to_json
+      )
+
+    content = RubyLLM::Content.new("What is this?", "https://example.com/cat.png")
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.add_message(role: :user, content: content)
+    chat.complete
+
+    span = EXPORTER.finished_spans.first
+    input_messages = JSON.parse(span.attributes["gen_ai.input.messages"])
+    assert_equal(
+      [
+        { "type" => "text", "content" => "What is this?" },
+        {
+          "type" => "uri",
+          "modality" => "image",
+          "mime_type" => "image/png",
+          "uri" => "https://example.com/cat.png"
+        }
+      ],
+      input_messages[0]["parts"]
+    )
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+  end
+
+  def test_captures_ruby_llm_content_raw
+    skip "RubyLLM::Content::Raw not available before ruby_llm 1.9.0" unless defined?(RubyLLM::Content::Raw)
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          id: "chatcmpl-123",
+          object: "chat.completion",
+          model: "gpt-4o-mini",
+          choices: [{
+            index: 0,
+            message: { role: "assistant", content: "Acknowledged." },
+            finish_reason: "stop"
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+        }.to_json
+      )
+
+    raw = RubyLLM::Content::Raw.new([{ type: "text", text: "raw payload" }])
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.add_message(role: :user, content: raw)
+    chat.complete
+
+    span = EXPORTER.finished_spans.first
+    input_messages = JSON.parse(span.attributes["gen_ai.input.messages"])
+    assert_equal(
+      [{ "type" => "raw", "content" => [{ "type" => "text", "text" => "raw payload" }] }],
+      input_messages[0]["parts"]
+    )
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+  end
+
+  def test_captures_ruby_llm_content_raw_system_instructions
+    skip "RubyLLM::Content::Raw not available before ruby_llm 1.9.0" unless defined?(RubyLLM::Content::Raw)
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(
+        status: 200,
+        headers: { "Content-Type" => "application/json" },
+        body: {
+          id: "chatcmpl-123",
+          object: "chat.completion",
+          model: "gpt-4o-mini",
+          choices: [{
+            index: 0,
+            message: { role: "assistant", content: "Acknowledged." },
+            finish_reason: "stop"
+          }],
+          usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+        }.to_json
+      )
+
+    raw_block = RubyLLM::Content::Raw.new([{ type: "text", text: "You are helpful" }])
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.add_message(role: :system, content: raw_block)
+    chat.add_message(role: :user, content: "Hi")
+    chat.complete
+
+    span = EXPORTER.finished_spans.first
+    system_instructions = JSON.parse(span.attributes["gen_ai.system_instructions"])
+    assert_equal(
+      [{ "type" => "raw", "content" => [{ "type" => "text", "text" => "You are helpful" }] }],
+      system_instructions
+    )
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+  end
+
   def test_captures_content_when_enabled_via_env_var
     ENV["OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT"] = "true"
 


### PR DESCRIPTION
## Summary

When capturing message content, `format_message` and `format_system_instructions` called `content.to_s`. For `RubyLLM::Content` and `RubyLLM::Content::Raw` that produces their inspect string instead of the actual content, so traces showed:

```
type: "text"
content: "#<RubyLLM::Content:0x00007f3e6eaf7400>"
```

This PR captures the real structured content and emits it in the shape defined by the OpenTelemetry GenAI semantic conventions for messages. The conversion is also moved out of the `RubyLLM::Chat` patch into a dedicated `MessageFormatter`, so the patched class stays free of formatting logic.

## GenAI semantic conventions

The span attributes follow the GenAI message schemas, where each message is `{ role, parts }` and every part has a `type` that selects its shape:

- [`gen-ai-input-messages.json`](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-input-messages.json) — `gen_ai.input.messages`
- [`gen-ai-output-messages.json`](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-output-messages.json) — `gen_ai.output.messages`
- [`gen-ai-system-instructions.json`](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-system-instructions.json) — `gen_ai.system_instructions` (a flat array of parts, no `role`)

Relevant part types from the spec:

| `type` | Fields | Used for |
| --- | --- | --- |
| `text` | `content` | plain strings and `RubyLLM::Content#text` |
| `uri` | `modality`, `mime_type`, `uri` | URL-backed attachments |
| `blob` | `modality`, `mime_type`, `content` | non-URL attachments (path / IO / ActiveStorage) |
| `tool_call` | `id`, `name`, `arguments` | assistant tool calls |
| GenericPart | any custom `type` + extra fields | provider-specific `Content::Raw` payloads |

`modality` is one of `image`, `video`, `audio`, `document`.

## Changes

### Content conversion

`MessageFormatter.format_content` handles each content shape explicitly (rather than relying on `to_s`, which only works for plain strings):

- **`RubyLLM::Content`** → a `text` part for `.text` (when present) plus one part per attachment.
- **`RubyLLM::Content::Raw`** → a `raw` GenericPart whose `content` is the provider payload (`content.value`) JSON-encoded, so consumers like Langfuse render it as readable text instead of `[object Object]`. A custom `type` is used so the payload never clashes with a standard part type.
- **plain String / other** → a single `text` part via `to_s` (existing behavior).

`Content::Raw` is guarded with `defined?(::RubyLLM::Content::Raw)` because the constant only exists in ruby_llm >= 1.9.0.

### Attachment mapping

Previously attachments were not captured at all — the whole `RubyLLM::Content` collapsed to its inspect string. `format_attachment` now maps each `RubyLLM::Attachment` onto the spec's binary part types:

- A **URL-backed** attachment (`attachment.url?`) becomes a `uri` part with the URL in `uri`.
- Any other source (local path, IO, ActiveStorage) becomes a `blob` part with the source in `content`.
- Both carry `mime_type` (when known) and a `modality` derived from `attachment.type`: `:image → image`, `:video → video`, `:audio → audio`, and `:pdf`/`:text`/`:unknown → document`.

### Refactor

- Move all formatting (`format_input_messages`, `format_output_messages`, `format_system_instructions`, and the private helpers) into `OpenTelemetry::Instrumentation::RubyLLM::MessageFormatter`. The `RubyLLM::Chat` patch now just delegates:

  ```ruby
  span.set_attribute("gen_ai.system_instructions", MessageFormatter.format_system_instructions(system_messages))
  span.set_attribute("gen_ai.input.messages", MessageFormatter.format_input_messages(input_messages))
  span.set_attribute("gen_ai.output.messages", MessageFormatter.format_output_messages([response]))
  ```

- Reuse `format_content` from `format_system_instructions`, so system messages get the same treatment.

### Tests

- `RubyLLM::Content` with a URL attachment → `text` part + `uri` part with `modality`/`mime_type`.
- `RubyLLM::Content::Raw` as user content → a `raw` GenericPart with the JSON-encoded payload.
- `RubyLLM::Content::Raw` as a system message → same, in `gen_ai.system_instructions`.

> Note: a text-only `RubyLLM::Content` is unwrapped back to a plain String by `RubyLLM::Message#content`, so only `Content`-with-attachments and `Content::Raw` actually reach this code as objects — those are what the tests cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
