### PR TITLE
Add configurable tool_result_max_length for tool result spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ When enabled, the following attributes are added to chat spans:
 > [!WARNING]
 > Captured content may include sensitive or personally identifiable information (PII). Use with caution in production environments.
 
+### Tool result length
+
+Tool call results are recorded on `execute_tool` spans via `gen_ai.tool.call.result`, truncated to 500 characters by default. Adjust the limit with `tool_result_max_length`:
+
+```ruby
+OpenTelemetry::SDK.configure do |c|
+  c.use 'OpenTelemetry::Instrumentation::RubyLLM', tool_result_max_length: 1000
+end
+```
+
 ### Custom attributes
 
 Use `with_otel_attributes` to add arbitrary attributes to the span for each request. This is useful for adding per-request metadata like Langfuse prompt linking or trace-level tags:

--- a/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
@@ -10,6 +10,7 @@ module OpenTelemetry
         instrumentation_version VERSION
 
         option :capture_content, default: false, validate: :boolean
+        option :tool_result_max_length, default: 500, validate: :integer
 
         present do
           defined?(::RubyLLM)

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -91,7 +91,7 @@ module OpenTelemetry
 
               # `RubyLLM::Tool::Halt#to_s` returns `@content.to_s`, so a single
               # `to_s` covers both the Halt and plain-result cases.
-              span.set_attribute("gen_ai.tool.call.result", result.to_s[0..500])
+              span.set_attribute("gen_ai.tool.call.result", result.to_s[0, tool_result_max_length])
 
               result
             end
@@ -104,6 +104,10 @@ module OpenTelemetry
             return env_value.to_s.strip.casecmp("true").zero? unless env_value.nil?
 
             RubyLLM::Instrumentation.instance.config[:capture_content]
+          end
+
+          def tool_result_max_length
+            RubyLLM::Instrumentation.instance.config[:tool_result_max_length]
           end
 
           def tracer

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -285,6 +285,68 @@ class InstrumentationTest < Minitest::Test
     assert_equal "function", tool_span.attributes["gen_ai.tool.type"]
   end
 
+  def test_truncates_tool_result_to_configured_max_length
+    long_value = "x" * 1000
+    echo = Class.new(RubyLLM::Tool) do
+      def self.name = "echo"
+      description "Echoes a long string"
+
+      define_method(:execute) { long_value }
+    end
+
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(
+        {
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            id: "chatcmpl-echo",
+            object: "chat.completion",
+            model: "gpt-4o-mini",
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: nil,
+                tool_calls: [{
+                  id: "call_echo",
+                  type: "function",
+                  function: { name: "echo", arguments: "{}" }
+                }]
+              },
+              finish_reason: "tool_calls"
+            }],
+            usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 }
+          }.to_json
+        },
+        {
+          status: 200,
+          headers: { "Content-Type" => "application/json" },
+          body: {
+            id: "chatcmpl-echo2",
+            object: "chat.completion",
+            model: "gpt-4o-mini",
+            choices: [{
+              index: 0,
+              message: { role: "assistant", content: "done" },
+              finish_reason: "stop"
+            }],
+            usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 }
+          }.to_json
+        }
+      )
+
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:tool_result_max_length] = 700
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini").with_tool(echo)
+    chat.ask("echo please")
+
+    tool_span = EXPORTER.finished_spans.find { |s| s.name.start_with?("execute_tool ") }
+    assert_equal "x" * 700, tool_span.attributes["gen_ai.tool.call.result"]
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:tool_result_max_length] = 500
+  end
+
   def test_records_error_when_tool_raises
     boom = Class.new(RubyLLM::Tool) do
       def self.name = "boom"


### PR DESCRIPTION
Tool results can be quite large (RAG docs, JSON responses, DB rows), and the current hardcoded limit sometimes truncates important context.

For evaluation and development, we need access to the full tool output - partial data isn’t enough to properly assess retrieval quality or build reliable eval datasets. Since tools like MLflow, Arize Phoenix, Traceloop, etc support full tool I/O, I think this limit should be configurable rather than hardcoded.
