### PR TITLE
Automatically set conversation id on chat spans of persisted records

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,10 @@ gem "opentelemetry-sdk"
 gem "opentelemetry-exporter-otlp"
 
 group :test do
+  gem "activerecord"
   gem "appraisal", "~> 2.5"
   gem "minitest"
   gem "rake"
+  gem "sqlite3"
   gem "webmock"
 end

--- a/README.md
+++ b/README.md
@@ -97,9 +97,21 @@ Attributes persist across calls on the same chat instance and the method returns
 
 ### Conversation and user tracking
 
-To correlate multi-turn conversations, set `gen_ai.conversation.id` via `with_otel_attributes`
-using a real conversation/session identifier from your application (e.g. a thread or chat
-record id):
+When a chat is a persisted `acts_as_chat` record from
+[RubyLLM's Rails integration](https://rubyllm.com/rails/), its chat spans automatically
+carry `gen_ai.conversation.id` set to the record's id — multi-turn conversations
+correlate (and group as sessions in backends like Langfuse) with no extra code:
+
+```ruby
+chat_record = Chat.create!(model: "gpt-4o-mini")
+chat_record.ask("Hi")
+```
+
+This applies to the modern `acts_as` API (`config.use_new_acts_as = true`). Everywhere
+else — plain `RubyLLM.chat`, the legacy `acts_as` API, or a conversation store outside
+ActiveRecord — set `gen_ai.conversation.id` via `with_otel_attributes` using a real
+conversation/session identifier from your application. An id you set this way always
+wins over the automatic one:
 
 ```ruby
 chat.with_otel_attributes("gen_ai.conversation.id" => session.id)
@@ -139,7 +151,8 @@ This produces one trace rooted at `invoke_agent ResearchAgent`
 (`gen_ai.operation.name` = `invoke_agent`, `gen_ai.agent.name` = `ResearchAgent`), with
 the chat and tool spans nested beneath it.
 
-When the agent's chat is a persisted `acts_as_chat` record, the span also carries
+When the agent's chat is a persisted `acts_as_chat` record on the modern `acts_as` API,
+the `invoke_agent` span and the chat spans nested beneath it all carry
 `gen_ai.conversation.id` set to the record's id, so multi-turn conversations correlate
 across jobs and requests without any extra code.
 
@@ -170,7 +183,7 @@ agent.ask("...")
 | Agent invocations (`invoke_agent` spans) | Supported (`ruby_llm` >= 1.12.1) |
 | Error handling | Supported |
 | Opt-in input/output content capture | Supported |
-| Conversation tracking (`gen_ai.conversation.id`) | Supported (automatic for persisted agent chats, or set your own id via `with_otel_attributes`) |
+| Conversation tracking (`gen_ai.conversation.id`) | Supported (automatic for persisted `acts_as_chat` records, or set your own id via `with_otel_attributes`) |
 | System instructions capture | Supported (via `capture_content`) |
 | Custom attributes on traces and spans | Supported (via `with_otel_attributes`) |
 | Embeddings | Supported |

--- a/gemfiles/ruby_llm_1.12.1.gemfile
+++ b/gemfiles/ruby_llm_1.12.1.gemfile
@@ -7,9 +7,11 @@ gem "opentelemetry-sdk"
 gem "opentelemetry-exporter-otlp"
 
 group :test do
+  gem "activerecord"
   gem "appraisal", "~> 2.5"
   gem "minitest"
   gem "rake"
+  gem "sqlite3"
   gem "webmock"
 end
 

--- a/gemfiles/ruby_llm_1.8.0.gemfile
+++ b/gemfiles/ruby_llm_1.8.0.gemfile
@@ -7,9 +7,11 @@ gem "opentelemetry-sdk"
 gem "opentelemetry-exporter-otlp"
 
 group :test do
+  gem "activerecord"
   gem "appraisal", "~> 2.5"
   gem "minitest"
   gem "rake"
+  gem "sqlite3"
   gem "webmock"
 end
 

--- a/gemfiles/ruby_llm_1_latest.gemfile
+++ b/gemfiles/ruby_llm_1_latest.gemfile
@@ -7,9 +7,11 @@ gem "opentelemetry-sdk"
 gem "opentelemetry-exporter-otlp"
 
 group :test do
+  gem "activerecord"
   gem "appraisal", "~> 2.5"
   gem "minitest"
   gem "rake"
+  gem "sqlite3"
   gem "webmock"
 end
 

--- a/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/instrumentation.rb
@@ -44,6 +44,24 @@ module OpenTelemetry
             require_relative "patches/agent"
             ::RubyLLM::Agent.prepend(Patches::Agent)
           end
+
+          begin
+            require "active_support/lazy_load_hooks"
+
+            ::ActiveSupport.on_load(:active_record) do
+              require "ruby_llm/active_record/chat_methods"
+              require_relative "patches/chat_methods"
+              ::RubyLLM::ActiveRecord::ChatMethods.prepend(Patches::ChatMethods)
+            rescue LoadError
+              OpenTelemetry.logger.warn(
+                "[OpenTelemetry::Instrumentation::RubyLLM] could not load " \
+                "ruby_llm/active_record/chat_methods; gen_ai.conversation.id " \
+                "will not be set automatically on persisted chat records."
+              )
+            end
+          rescue LoadError
+            nil
+          end
         end
       end
     end

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/agent.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/agent.rb
@@ -29,7 +29,8 @@ module OpenTelemetry
             agent_name = self.class.name
             attributes = { "gen_ai.operation.name" => "invoke_agent" }
             attributes["gen_ai.agent.name"] = agent_name if agent_name
-            attributes["gen_ai.conversation.id"] = chat.id.to_s if chat.respond_to?(:persisted?) && chat.persisted?
+            conversation_id = llm_chat.otel_conversation_id if llm_chat.respond_to?(:otel_conversation_id)
+            attributes["gen_ai.conversation.id"] = conversation_id if conversation_id
 
             span_name = agent_name ? "invoke_agent #{agent_name}" : "invoke_agent"
 

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -5,6 +5,13 @@ module OpenTelemetry
     module RubyLLM
       module Patches
         module Chat
+          attr_writer :otel_conversation_id
+
+          def otel_conversation_id
+            id = @otel_attributes&.[]("gen_ai.conversation.id") || @otel_conversation_id
+            id.respond_to?(:call) ? id.call : id
+          end
+
           def with_otel_attributes(attributes)
             @otel_attributes = attributes
             self
@@ -19,6 +26,8 @@ module OpenTelemetry
               "gen_ai.provider.name" => provider,
               "gen_ai.request.model" => model_id,
             }
+            conversation_id = otel_conversation_id
+            attributes["gen_ai.conversation.id"] = conversation_id if conversation_id
             # Per GenAI semconv: set `gen_ai.request.stream` if and only if
             # the request is streaming. Absence means non-streaming.
             attributes["gen_ai.request.stream"] = true if block_given?

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat_methods.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat_methods.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module OpenTelemetry
+  module Instrumentation
+    module RubyLLM
+      module Patches
+        module ChatMethods
+          def to_llm(...)
+            chat = super
+            chat.otel_conversation_id = id.to_s if persisted?
+            chat
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/active_record_chat_methods_test.rb
+++ b/test/active_record_chat_methods_test.rb
@@ -1,0 +1,195 @@
+require "active_record"
+require_relative "test_helper"
+
+gem_dir = Gem.loaded_specs.fetch("ruby_llm").full_gem_path
+Dir[File.join(gem_dir, "lib/ruby_llm/active_record/*.rb")].sort.each { |file| require file }
+
+ActiveRecord::Base.establish_connection(adapter: "sqlite3", database: ":memory:")
+ActiveRecord::Base.include RubyLLM::ActiveRecord::ActsAs
+
+RubyLLM::Models.class_eval do
+  if method_defined?(:load_models)
+    def load_models
+      read_from_json
+    end
+  else
+    def self.load_models(file = RubyLLM.config.model_registry_file)
+      read_from_json(file)
+    end
+  end
+end
+
+ActiveRecord::Schema.verbose = false
+ActiveRecord::Schema.define do
+  create_table :models do |t|
+    t.string :model_id, null: false
+    t.string :name, null: false
+    t.string :provider, null: false
+    t.string :family
+    t.datetime :model_created_at
+    t.integer :context_window
+    t.integer :max_output_tokens
+    t.date :knowledge_cutoff
+    t.json :modalities, default: {}
+    t.json :capabilities, default: []
+    t.json :pricing, default: {}
+    t.json :metadata, default: {}
+    t.timestamps
+  end
+
+  create_table :chats do |t|
+    t.references :model
+    t.timestamps
+  end
+
+  create_table :messages do |t|
+    t.string :role, null: false
+    t.text :content
+    t.json :content_raw
+    t.text :thinking_text
+    t.text :thinking_signature
+    t.integer :thinking_tokens
+    t.integer :input_tokens
+    t.integer :output_tokens
+    t.integer :cached_tokens
+    t.integer :cache_creation_tokens
+    t.references :chat, null: false
+    t.references :model
+    t.references :tool_call
+    t.timestamps
+  end
+
+  create_table :tool_calls do |t|
+    t.string :tool_call_id, null: false
+    t.string :name, null: false
+    t.text :thought_signature
+    t.json :arguments, default: {}
+    t.references :message, null: false
+    t.timestamps
+  end
+end
+
+class Model < ActiveRecord::Base
+  acts_as_model
+end
+
+class Chat < ActiveRecord::Base
+  acts_as_chat
+end
+
+class Message < ActiveRecord::Base
+  acts_as_message
+end
+
+class ToolCall < ActiveRecord::Base
+  acts_as_tool_call
+end
+
+if defined?(RubyLLM::Agent)
+  class SupportAgent < RubyLLM::Agent
+  end
+end
+
+class ActiveRecordChatMethodsTest < Minitest::Test
+  include ChatCompletionStubs
+
+  def setup
+    EXPORTER.reset
+
+    RubyLLM.configure do |c|
+      c.openai_api_key = "fake-key-for-testing"
+    end
+  end
+
+  def find_or_create_model
+    Model.find_or_create_by!(model_id: "gpt-4o-mini", provider: "openai") do |m|
+      m.name = "GPT-4o Mini"
+    end
+  end
+
+  def create_chat_record
+    Chat.create!(model: find_or_create_model)
+  end
+
+  def find_chat_span
+    EXPORTER.finished_spans.find { |s| s.name.start_with?("chat ") }
+  end
+
+  def find_agent_span
+    EXPORTER.finished_spans.find { |s| s.name.start_with?("invoke_agent") }
+  end
+
+  def test_persisted_record_ask_stamps_conversation_id_on_chat_span
+    stub_chat_completion
+
+    chat_record = create_chat_record
+    chat_record.ask("Hi")
+
+    assert_equal chat_record.id.to_s, find_chat_span.attributes["gen_ai.conversation.id"]
+  end
+
+  def test_plain_chat_span_carries_no_conversation_id
+    stub_chat_completion
+
+    RubyLLM.chat(model: "gpt-4o-mini").ask("Hi")
+
+    assert_nil find_chat_span.attributes["gen_ai.conversation.id"]
+  end
+
+  def test_unpersisted_record_chat_is_not_stamped_until_persisted
+    chat_record = Chat.new(model: find_or_create_model)
+
+    assert_nil chat_record.to_llm.otel_conversation_id
+
+    chat_record.save!
+
+    assert_equal chat_record.id.to_s, chat_record.to_llm.otel_conversation_id
+  end
+
+  def test_user_otel_attributes_are_preserved_alongside_conversation_id
+    stub_chat_completion
+
+    chat_record = create_chat_record
+    chat_record.to_llm.with_otel_attributes("enduser.id" => "user-1")
+    chat_record.ask("Hi")
+
+    span = find_chat_span
+    assert_equal "user-1", span.attributes["enduser.id"]
+    assert_equal chat_record.id.to_s, span.attributes["gen_ai.conversation.id"]
+  end
+
+  def test_user_supplied_conversation_id_wins_over_record_id
+    stub_chat_completion
+
+    chat_record = create_chat_record
+    chat_record.to_llm.with_otel_attributes("gen_ai.conversation.id" => "custom-id")
+    chat_record.ask("Hi")
+
+    assert_equal "custom-id", find_chat_span.attributes["gen_ai.conversation.id"]
+  end
+
+  if defined?(RubyLLM::Agent)
+    def test_agent_flow_carries_conversation_id_on_root_and_chat_spans
+      stub_chat_completion
+
+      chat_record = create_chat_record
+      agent = SupportAgent.new(chat: chat_record)
+      agent.ask("Hi")
+
+      assert_equal chat_record.id.to_s, find_agent_span.attributes["gen_ai.conversation.id"]
+      assert_equal chat_record.id.to_s, find_chat_span.attributes["gen_ai.conversation.id"]
+    end
+
+    def test_user_supplied_conversation_id_wins_on_agent_and_chat_spans
+      stub_chat_completion
+
+      chat_record = create_chat_record
+      chat_record.to_llm.with_otel_attributes("gen_ai.conversation.id" => "custom-id")
+      agent = SupportAgent.new(chat: chat_record)
+      agent.ask("Hi")
+
+      assert_equal "custom-id", find_agent_span.attributes["gen_ai.conversation.id"]
+      assert_equal "custom-id", find_chat_span.attributes["gen_ai.conversation.id"]
+    end
+  end
+end

--- a/test/agent_instrumentation_test.rb
+++ b/test/agent_instrumentation_test.rb
@@ -64,12 +64,11 @@ if defined?(RubyLLM::Agent)
       assert_nil agent_span.attributes["gen_ai.agent.name"]
     end
 
-    def test_sets_conversation_id_for_persisted_chat_records
+    def test_sets_conversation_id_stamped_on_the_chat
       stub_chat_completion
 
       chat = RubyLLM.chat(model: "gpt-4o-mini")
-      chat.define_singleton_method(:persisted?) { true }
-      chat.define_singleton_method(:id) { 42 }
+      chat.otel_conversation_id = "42"
 
       agent = ResearchAgent.new(chat: chat)
       agent.ask("Hi")
@@ -141,10 +140,9 @@ if defined?(RubyLLM::Agent)
       stub_chat_completion
 
       llm_chat = RubyLLM.chat(model: "gpt-4o-mini")
+      llm_chat.otel_conversation_id = "7"
       record = Object.new
       record.define_singleton_method(:to_llm) { llm_chat }
-      record.define_singleton_method(:persisted?) { true }
-      record.define_singleton_method(:id) { 7 }
       record.define_singleton_method(:ask) { |message| llm_chat.ask(message) }
 
       agent = ResearchAgent.new(chat: record)


### PR DESCRIPTION
This stamps the conversation id on traces by introducing a prepend on `RubyLLM::ActiveRecord::ChatMethods#to_llm` that hands the record id to the Chat patch through a dedicated `otel_conversation_id` writer rather than only through manually setting `with_otel_attributes`.

`with_otel_attributes` are still applied last, so if users have been supplying their own `gen_ai.conversation.id`, it wins over the automatic one being introduced.

The legacy `acts_as` API (where `use_new_acts_as` is set to `false`) uses a different module and keeps the documented manual path.