### PR TITLE
fix: trace otel attributes when exceptions are raised

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -72,9 +72,9 @@ module OpenTelemetry
                 end
               end
 
-              @otel_attributes&.each { |key, value| span.set_attribute(key, value.respond_to?(:call) ? value.call : value) }
-
               result
+            ensure
+              @otel_attributes&.each { |key, value| span.set_attribute(key, value.respond_to?(:call) ? value.call : value) }
             end
           end
 

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -406,6 +406,27 @@ class InstrumentationTest < Minitest::Test
     assert_equal "fixed", span.attributes["custom.static"]
   end
 
+  def test_with_otel_attributes_applied_on_api_failure
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.with_otel_attributes(
+      "langfuse.trace.name" => "My Agent",
+      "custom.last_role" => -> { chat.messages.last&.role.to_s }
+    )
+
+    assert_raises do
+      chat.ask("Hi")
+    end
+
+    span = EXPORTER.finished_spans.last
+    assert_equal "chat gpt-4o-mini", span.name
+    assert_equal OpenTelemetry::Trace::Status::ERROR, span.status.code
+    assert_equal "My Agent", span.attributes["langfuse.trace.name"]
+    assert_equal "user", span.attributes["custom.last_role"]
+  end
+
   def test_works_without_otel_attributes
     stub_chat_completion(chat_completion_body(content: "Hello!"))
 


### PR DESCRIPTION
## Context

I'm using [Langfuse](https://langfuse.com/) to monitor my agents and noticed that when an exception is raised, empty traces are being generated and they do not show any context about the agent that was executed.

<img width="1325" height="619" alt="image" src="https://github.com/user-attachments/assets/0352d9b2-aa73-482c-90d5-bd9f9fd5371a" />

In this case, OpenAI returned a 500 error and RubyLLM raised a `RubyLLM::ServerError`

## Proposed solution

Enforce that `@otel_attributes` are always set in the span, so traces will contain the fields even when providers fail to generate a response