### PR TITLE
Serialize hash tool results as JSON

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -98,9 +98,10 @@ module OpenTelemetry
                 raise
               end
 
-              # `RubyLLM::Tool::Halt#to_s` returns `@content.to_s`, so a single
-              # `to_s` covers both the Halt and plain-result cases.
-              span.set_attribute("gen_ai.tool.call.result", result.to_s[0, tool_result_max_length])
+              # `RubyLLM::Tool::Halt#to_s` returns `@content.to_s`, so preserve
+              # `to_s` for Halt and plain-result cases while serializing hashes.
+              tool_result = result.is_a?(Hash) ? result.to_json : result.to_s
+              span.set_attribute("gen_ai.tool.call.result", tool_result[0, tool_result_max_length])
 
               result
             end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -250,6 +250,37 @@ class InstrumentationTest < Minitest::Test
     OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:tool_result_max_length] = 500
   end
 
+  def test_serializes_hash_tool_result_as_json
+    structured_tool = Class.new(RubyLLM::Tool) do
+      def self.name = "structured_tool"
+      description "Returns structured data"
+
+      def execute
+        { answer: 4, source: "calculator" }
+      end
+    end
+
+    stub_chat_completion(
+      chat_completion_body(
+        content: nil,
+        tool_calls: [{
+          id: "call_structured",
+          type: "function",
+          function: { name: "structured", arguments: "{}" }
+        }]
+      ),
+      chat_completion_body(
+        content: "The answer is 4",
+        usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 }
+      )
+    )
+
+    RubyLLM.chat(model: "gpt-4o-mini").with_tool(structured_tool).ask("What is 2+2?")
+
+    tool_span = EXPORTER.finished_spans.find { |s| s.name.start_with?("execute_tool ") }
+    assert_equal({ "answer" => 4, "source" => "calculator" }, JSON.parse(tool_span.attributes["gen_ai.tool.call.result"]))
+  end
+
   def test_records_error_when_tool_raises
     boom = Class.new(RubyLLM::Tool) do
       def self.name = "boom"


### PR DESCRIPTION
While inspecting `gen_ai.tool.call.result`, I noticed hash results were recorded using Ruby’s hash format rather than valid JSON. 

This change serializes hash tool results with `to_json` before recording `gen_ai.tool.call.result`, producing valid JSON instead of Ruby hash syntax.