### PR TITLE
Add env var override for tool_result_max_length

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@ OpenTelemetry::SDK.configure do |c|
 end
 ```
 
+Or set the environment variable:
+
+```bash
+export OTEL_INSTRUMENTATION_GENAI_TOOL_RESULT_MAX_LENGTH=1000
+```
+
 ### Custom attributes
 
 Use `with_otel_attributes` to add arbitrary attributes to the span for each request. This is useful for adding per-request metadata like Langfuse prompt linking or trace-level tags:

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -116,6 +116,12 @@ module OpenTelemetry
           end
 
           def tool_result_max_length
+            env_value = ENV["OTEL_INSTRUMENTATION_GENAI_TOOL_RESULT_MAX_LENGTH"]
+            unless env_value.nil?
+              parsed = Integer(env_value.to_s.strip, exception: false)
+              return parsed unless parsed.nil?
+            end
+
             RubyLLM::Instrumentation.instance.config[:tool_result_max_length]
           end
 

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -117,7 +117,7 @@ module OpenTelemetry
 
           def tool_result_max_length
             env_value = ENV["OTEL_INSTRUMENTATION_GENAI_TOOL_RESULT_MAX_LENGTH"]
-            unless env_value.nil?
+            if env_value
               parsed = Integer(env_value.to_s.strip, exception: false)
               return parsed unless parsed.nil?
             end


### PR DESCRIPTION
Adds support for configuring tool result truncation length via `OTEL_INSTRUMENTATION_GENAI_TOOL_RESULT_MAX_LENGTH`, with fallback to configured `tool_result_max_length` value.