### PR TITLE
Capture gen_ai.tool.definitions on chat and invoke_agent spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ When enabled, the following attributes are added to chat spans:
 | `gen_ai.system_instructions` | System instructions provided via `with_instructions` |
 | `gen_ai.input.messages` | Input messages sent to the model |
 | `gen_ai.output.messages` | Final output messages from the model |
+| `gen_ai.tool.definitions` | Definitions of the tools available to the model (name, description, parameter JSON Schema), set only when the chat has tools |
 
 > [!WARNING]
 > Captured content may include sensitive or personally identifiable information (PII). Use with caution in production environments.
@@ -157,9 +158,10 @@ the `invoke_agent` span and the chat spans nested beneath it all carry
 across jobs and requests without any extra code.
 
 With `capture_content` enabled, the `invoke_agent` span also records
-`gen_ai.input.messages` (the conversation history going in) and
-`gen_ai.output.messages` (the final response), so backends that read the trace root
-— like Langfuse — show the run's input and output at the trace level.
+`gen_ai.input.messages` (the conversation history going in),
+`gen_ai.output.messages` (the final response) and `gen_ai.tool.definitions` (the
+agent's tools), so backends that read the trace root — like Langfuse — show the run's
+input, output and available tools at the trace level.
 
 Only agent *instances* are wrapped. Class-level entry points that return the chat
 record itself (`ResearchAgent.find(id)`, `ResearchAgent.create!`) bypass the agent
@@ -185,6 +187,7 @@ agent.ask("...")
 | Opt-in input/output content capture | Supported |
 | Conversation tracking (`gen_ai.conversation.id`) | Supported (automatic for persisted `acts_as_chat` records, or set your own id via `with_otel_attributes`) |
 | System instructions capture | Supported (via `capture_content`) |
+| Tool definitions capture (`gen_ai.tool.definitions`) | Supported (via `capture_content`) |
 | Custom attributes on traces and spans | Supported (via `with_otel_attributes`) |
 | Embeddings | Supported |
 | Streaming | Planned |

--- a/lib/opentelemetry/instrumentation/ruby_llm/message_formatter.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/message_formatter.rb
@@ -3,13 +3,14 @@
 module OpenTelemetry
   module Instrumentation
     module RubyLLM
-      # Converts `RubyLLM` messages and content into the JSON shape defined by
-      # the GenAI semantic conventions for input/output messages and system
-      # instructions:
+      # Converts `RubyLLM` messages, content and tools into the JSON shape
+      # defined by the GenAI semantic conventions for input/output messages,
+      # system instructions and tool definitions:
       #
-      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-input-messages.json
-      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-output-messages.json
-      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/docs/gen-ai/gen-ai-system-instructions.json
+      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-input-messages.json
+      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-output-messages.json
+      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-system-instructions.json
+      #   https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-tool-definitions.json
       #
       # Kept separate from the `RubyLLM::Chat` patch so the formatting logic
       # does not pollute the patched class.
@@ -24,6 +25,46 @@ module OpenTelemetry
 
         def self.format_system_instructions(messages)
           messages.flat_map { |m| format_content(m.content) }.to_json
+        end
+
+        # `tools` may be a `RubyLLM::Chat#tools` hash (name => tool instance)
+        # or a plain collection of tool instances. Returns `nil` when there are
+        # no tools, so callers can skip setting the attribute.
+        def self.format_tool_definitions(tools)
+          list = tools.respond_to?(:values) ? tools.values : Array(tools)
+          return nil if list.empty?
+
+          list.map { |tool| format_tool_definition(tool) }.to_json
+        end
+
+        private_class_method def self.format_tool_definition(tool)
+          definition = { type: "function", name: tool.name }
+          definition[:description] = tool.description if tool.description
+          parameters = format_tool_parameters(tool)
+          definition[:parameters] = parameters if parameters
+          definition
+        end
+
+        # Returns the JSON Schema document describing the tool's parameters.
+        private_class_method def self.format_tool_parameters(tool)
+          # `RubyLLM::Tool#params_schema` was added in ruby_llm 1.9.0; older
+          # versions only expose `RubyLLM::Parameter` objects, so build the
+          # schema the same way the 1.8.0 providers do.
+          return tool.params_schema if tool.respond_to?(:params_schema)
+          return nil unless tool.respond_to?(:parameters)
+
+          parameters = tool.parameters
+          return nil if parameters.nil? || parameters.empty?
+
+          properties = parameters.to_h do |name, param|
+            [name.to_s, { type: param.type.to_s, description: param.description }.compact]
+          end
+
+          {
+            type: "object",
+            properties: properties,
+            required: parameters.select { |_, param| param.required }.keys.map(&:to_s)
+          }
         end
 
         private_class_method def self.format_message(message)

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/agent.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/agent.rb
@@ -31,6 +31,10 @@ module OpenTelemetry
             attributes["gen_ai.agent.name"] = agent_name if agent_name
             conversation_id = llm_chat.otel_conversation_id if llm_chat.respond_to?(:otel_conversation_id)
             attributes["gen_ai.conversation.id"] = conversation_id if conversation_id
+            if capture_content? && llm_chat.respond_to?(:tools)
+              tool_definitions = MessageFormatter.format_tool_definitions(llm_chat.tools)
+              attributes["gen_ai.tool.definitions"] = tool_definitions if tool_definitions
+            end
 
             span_name = agent_name ? "invoke_agent #{agent_name}" : "invoke_agent"
 

--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -31,6 +31,12 @@ module OpenTelemetry
             # Per GenAI semconv: set `gen_ai.request.stream` if and only if
             # the request is streaming. Absence means non-streaming.
             attributes["gen_ai.request.stream"] = true if block_given?
+            # Tool definitions describe the request, so they are set up front
+            # and stay on the span even when the request raises.
+            if capture_content?
+              tool_definitions = MessageFormatter.format_tool_definitions(tools)
+              attributes["gen_ai.tool.definitions"] = tool_definitions if tool_definitions
+            end
 
             tracer.in_span("chat #{model_id}", attributes: attributes, kind: OpenTelemetry::Trace::SpanKind::CLIENT) do |span|
               begin

--- a/test/agent_instrumentation_test.rb
+++ b/test/agent_instrumentation_test.rb
@@ -232,6 +232,39 @@ if defined?(RubyLLM::Agent)
       OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
     end
 
+    def test_captures_tool_definitions_on_agent_span_when_enabled
+      OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+      stub_chat_completion
+
+      weather = Class.new(RubyLLM::Tool) do
+        def self.name = "weather"
+        description "Looks up the weather"
+        param :city, type: "string", desc: "City name"
+
+        def execute(city:)
+          "Sunny in #{city}"
+        end
+      end
+
+      agent = ResearchAgent.new
+      agent.with_tool(weather)
+      agent.ask("Weather in Riga?")
+
+      agent_span = EXPORTER.finished_spans.find { |s| s.name.start_with?("invoke_agent") }
+      definition = JSON.parse(agent_span.attributes["gen_ai.tool.definitions"]).first
+
+      assert_equal "function", definition["type"]
+      assert_equal "weather", definition["name"]
+      assert_equal "Looks up the weather", definition["description"]
+      assert_equal(
+        { "type" => "string", "description" => "City name" },
+        definition["parameters"]["properties"]["city"]
+      )
+    ensure
+      OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+    end
+
     def test_does_not_capture_content_on_agent_span_by_default
       stub_chat_completion
 
@@ -240,6 +273,7 @@ if defined?(RubyLLM::Agent)
       agent_span = EXPORTER.finished_spans.find { |s| s.name.start_with?("invoke_agent") }
       assert_nil agent_span.attributes["gen_ai.input.messages"]
       assert_nil agent_span.attributes["gen_ai.output.messages"]
+      assert_nil agent_span.attributes["gen_ai.tool.definitions"]
     end
   end
 end

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -528,4 +528,115 @@ class InstrumentationTest < Minitest::Test
   ensure
     ENV.delete("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT")
   end
+
+  def test_does_not_capture_tool_definitions_by_default
+    stub_chat_completion
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.with_tool(calculator_tool)
+    chat.ask("What is 2+2?")
+
+    span = EXPORTER.finished_spans.first
+    assert_nil span.attributes["gen_ai.tool.definitions"]
+  end
+
+  def test_captures_tool_definitions_when_enabled
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+    stub_chat_completion
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.with_tool(calculator_tool)
+    chat.ask("What is 2+2?")
+
+    span = EXPORTER.finished_spans.first
+    tool_definitions = JSON.parse(span.attributes["gen_ai.tool.definitions"])
+
+    assert_equal 1, tool_definitions.length
+
+    definition = tool_definitions.first
+    assert_equal "function", definition["type"]
+    assert_equal "calculator", definition["name"]
+    assert_equal "Performs math", definition["description"]
+
+    parameters = definition["parameters"]
+    assert_equal "object", parameters["type"]
+    assert_equal({ "type" => "string", "description" => "Math expression" }, parameters["properties"]["expression"])
+    assert_equal ["expression"], parameters["required"]
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+  end
+
+  def test_omits_tool_definitions_when_no_tools_are_registered
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+    stub_chat_completion
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.ask("Hi")
+
+    span = EXPORTER.finished_spans.first
+    assert_nil span.attributes["gen_ai.tool.definitions"]
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+  end
+
+  def test_captures_tool_definitions_on_api_failure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+    stub_request(:post, "https://api.openai.com/v1/chat/completions")
+      .to_return(status: 500, body: "Internal Server Error")
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.with_tool(calculator_tool)
+
+    assert_raises { chat.ask("What is 2+2?") }
+
+    span = EXPORTER.finished_spans.last
+    tool_definitions = JSON.parse(span.attributes["gen_ai.tool.definitions"])
+    assert_equal ["calculator"], tool_definitions.map { |d| d["name"] }
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+  end
+
+  def test_captures_tool_definitions_without_a_description
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = true
+
+    stub_chat_completion
+
+    ping = Class.new(RubyLLM::Tool) do
+      def self.name = "ping"
+
+      def execute
+        "pong"
+      end
+    end
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+    chat.with_tool(ping)
+    chat.ask("Ping")
+
+    span = EXPORTER.finished_spans.first
+    definition = JSON.parse(span.attributes["gen_ai.tool.definitions"]).first
+
+    assert_equal "function", definition["type"]
+    assert_equal "ping", definition["name"]
+    refute definition.key?("description")
+  ensure
+    OpenTelemetry::Instrumentation::RubyLLM::Instrumentation.instance.config[:capture_content] = false
+  end
+
+  private
+
+  def calculator_tool
+    Class.new(RubyLLM::Tool) do
+      def self.name = "calculator"
+      description "Performs math"
+      param :expression, type: "string", desc: "Math expression"
+
+      def execute(expression:)
+        eval(expression).to_s
+      end
+    end
+  end
 end


### PR DESCRIPTION
Records the tools available to the model as `gen_ai.tool.definitions`, following the GenAI semantic conventions [tool definitions schema](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/gen-ai-tool-definitions.json).

Each entry is a `FunctionToolDefinition`: `type`, `name`, and — when the tool provides them — `description` and the `parameters` JSON Schema. Tools with no description or no parameters emit just the two required properties.

```json
[
  {
    "type": "function",
    "name": "calculator",
    "description": "Performs math",
    "parameters": {
      "type": "object",
      "properties": {
        "expression": { "type": "string", "description": "Math expression" }
      },
      "required": ["expression"],
      "additionalProperties": false,
      "strict": true
    }
  }
]
```

### Notes

- **Gating.** [`spans.yaml`](https://github.com/open-telemetry/semantic-conventions-genai/blob/main/model/gen-ai/spans.yaml) puts `gen_ai.tool.definitions` in the same `attributes.gen_ai.content` opt-in group as `gen_ai.input.messages` and `gen_ai.output.messages`, so it is gated on the existing `capture_content` option / `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT` env var rather than a new config knob. That group is referenced by both the inference (`chat`) and `invoke_agent` spans, so the attribute is set on both.
- **`description` and `parameters` are populated.** The schema marks them NOT RECOMMENDED by default, with instrumentations MAY offering a way to enable them. They are included here because they are the useful part, they describe static application code rather than user data, and `capture_content` is already an explicit opt-in covering far more sensitive message content. Happy to move them behind a separate option if you would rather follow the letter of the recommendation.
- **Set before the request runs.** Tool definitions describe the request, so they go into the initial span attributes and stay on the span when the API call raises.
- **`ruby_llm` 1.8.0 support.** Parameter schemas come from `RubyLLM::Tool#params_schema` where available (1.9.0+). On 1.8.0 that method does not exist, so the schema is built from the `RubyLLM::Parameter` objects the same way the 1.8.0 providers do — same `type`/`properties`/`required` shape, without the `additionalProperties`/`strict` keys that `params_schema` adds.

Also fixes the semantic-conventions links in `MessageFormatter`, which pointed at `docs/gen-ai/*.json` paths that 404 — those schemas live under `model/gen-ai/`.

### Testing

Tests cover: absent by default, full shape when enabled, omitted when the chat has no tools, present when the API call fails, `description` omitted for a tool without one, and the `invoke_agent` span case. Green against `ruby_llm` 1.16.0 and 1.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Langfuse example

<img width="753" height="832" alt="Screenshot 2026-08-20 at 19 14 01" src="https://github.com/user-attachments/assets/43c4dc32-7799-4be6-ba0a-c2e049031e8b" />
