### PR TITLE
Attribute usage to each level's own API call

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -32,6 +32,8 @@ module OpenTelemetry
             # the request is streaming. Absence means non-streaming.
             attributes["gen_ai.request.stream"] = true if block_given?
 
+            existing_messages = @messages.dup
+
             tracer.in_span("chat #{model_id}", attributes: attributes, kind: OpenTelemetry::Trace::SpanKind::CLIENT) do |span|
               begin
                 result = super
@@ -42,8 +44,8 @@ module OpenTelemetry
                 raise
               end
 
-              if @messages.last
-                response = @messages.last
+              response = (@messages - existing_messages).find { |m| m.role == :assistant }
+              if response
                 span.set_attribute("gen_ai.response.model", response.model_id) if response.model_id
                 span.set_attribute("gen_ai.usage.input_tokens", response.input_tokens) if response.input_tokens
                 span.set_attribute("gen_ai.usage.output_tokens", response.output_tokens) if response.output_tokens

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -215,6 +215,95 @@ class InstrumentationTest < Minitest::Test
     assert_equal "function", tool_span.attributes["gen_ai.tool.type"]
   end
 
+  def test_each_chat_span_reports_its_own_call_usage_in_tool_loop
+    calculator = Class.new(RubyLLM::Tool) do
+      def self.name = "calculator"
+      description "Performs math"
+      param :expression, type: "string", desc: "Math expression"
+
+      def execute(expression:)
+        eval(expression).to_s
+      end
+    end
+
+    stub_chat_completion(
+      chat_completion_body(
+        content: nil,
+        tool_calls: [{
+          id: "call_abc123",
+          type: "function",
+          function: { name: "calculator", arguments: '{"expression":"2+2"}' }
+        }],
+        usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 }
+      ),
+      chat_completion_body(
+        content: "The answer is 4",
+        usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 }
+      )
+    )
+
+    chat = RubyLLM.chat(model: "gpt-4o-mini").with_tool(calculator)
+    chat.ask("What is 2+2?")
+
+    chat_spans = EXPORTER.finished_spans.select { |s| s.name == "chat gpt-4o-mini" }
+    root_span = chat_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+    nested_span = (chat_spans - [root_span]).first
+
+    assert_equal 10, root_span.attributes["gen_ai.usage.input_tokens"]
+    assert_equal 3, root_span.attributes["gen_ai.usage.output_tokens"]
+    assert_equal 20, nested_span.attributes["gen_ai.usage.input_tokens"]
+    assert_equal 5, nested_span.attributes["gen_ai.usage.output_tokens"]
+  end
+
+  def test_usage_attribution_survives_message_list_changes_during_tool_loop
+    chat = RubyLLM.chat(model: "gpt-4o-mini")
+
+    mutator = Class.new(RubyLLM::Tool) do
+      def self.name = "mutator"
+      description "Changes the chat instructions"
+
+      define_method(:execute) do
+        chat.with_instructions("Be brief", append: true)
+        chat.with_instructions("Be kind", append: true)
+        "done"
+      end
+    end
+
+    stub_chat_completion(
+      chat_completion_body(
+        content: "First turn",
+        usage: { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 }
+      ),
+      chat_completion_body(
+        content: nil,
+        tool_calls: [{
+          id: "call_mut",
+          type: "function",
+          function: { name: "mutator", arguments: "{}" }
+        }],
+        usage: { prompt_tokens: 10, completion_tokens: 3, total_tokens: 13 }
+      ),
+      chat_completion_body(
+        content: "Second turn",
+        usage: { prompt_tokens: 20, completion_tokens: 5, total_tokens: 25 }
+      )
+    )
+
+    chat.with_tool(mutator)
+    chat.ask("Hi")
+    EXPORTER.reset
+    chat.ask("Go")
+
+    chat_spans = EXPORTER.finished_spans.select { |s| s.name == "chat gpt-4o-mini" }
+    root_span = chat_spans.find { |s| s.parent_span_id == OpenTelemetry::Trace::INVALID_SPAN_ID }
+    nested_span = (chat_spans - [root_span]).first
+
+    assert_equal 10, root_span.attributes["gen_ai.usage.input_tokens"]
+    assert_equal 3, root_span.attributes["gen_ai.usage.output_tokens"]
+    assert_equal 20, nested_span.attributes["gen_ai.usage.input_tokens"]
+    assert_equal 5, nested_span.attributes["gen_ai.usage.output_tokens"]
+  end
+
   def test_truncates_tool_result_to_configured_max_length
     long_value = "x" * 1000
     echo = Class.new(RubyLLM::Tool) do


### PR DESCRIPTION
## Problem

ruby_llm re-enters `Chat#complete` after every tool round, and the chat patch reads usage from `@messages.last` after `super` returns. In a tool-call loop, every nesting level reports the last call's usage: intermediate calls are never reported and the final call is reported once per level. With one tool call (two API calls), both `chat` spans carry the second call's usage, so cost backends that price these spans (like Langfuse) misprice the whole turn.

## Fix

Snapshot the message list by reference before `super` and attach the first assistant message that was not there when the level started. Comparison is by object identity, so attribution survives message-list reordering (`with_instructions` during a tool run partitions and rebuilds the array). Span names, count, nesting and every other attribute are unchanged; only which usage lands on each span changes.

## Tests

- `test_each_chat_span_reports_its_own_call_usage_in_tool_loop`: each of the two chat spans gets its own call's usage.
- `test_usage_attribution_survives_message_list_changes_during_tool_loop`: a tool appends instructions mid-loop. This test fails with index-based tracking (the span gets the previous turn's usage) and passes with identity-based tracking.