### PR TITLE
Emit gen_ai.usage.input_tokens inclusive of cached tokens

### DIFF
--- a/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
+++ b/lib/opentelemetry/instrumentation/ruby_llm/patches/chat.rb
@@ -44,8 +44,13 @@ module OpenTelemetry
 
               if @messages.last
                 response = @messages.last
+                cached_tokens = response.respond_to?(:cached_tokens) ? response.cached_tokens.to_i : 0
+                cache_creation_tokens = response.respond_to?(:cache_creation_tokens) ? response.cache_creation_tokens.to_i : 0
+
                 span.set_attribute("gen_ai.response.model", response.model_id) if response.model_id
-                span.set_attribute("gen_ai.usage.input_tokens", response.input_tokens) if response.input_tokens
+                if response.input_tokens
+                  span.set_attribute("gen_ai.usage.input_tokens", response.input_tokens.to_i + cached_tokens + cache_creation_tokens)
+                end
                 span.set_attribute("gen_ai.usage.output_tokens", response.output_tokens) if response.output_tokens
                 span.set_attribute("gen_ai.request.temperature", @temperature) if @temperature
 

--- a/test/instrumentation_test.rb
+++ b/test/instrumentation_test.rb
@@ -92,6 +92,7 @@ class InstrumentationTest < Minitest::Test
     chat.ask("Hi")
 
     span = EXPORTER.finished_spans.first
+    assert_equal 100, span.attributes["gen_ai.usage.input_tokens"]
     assert_equal 75, span.attributes["gen_ai.usage.cache_read.input_tokens"]
     assert_equal 0, span.attributes["gen_ai.usage.cache_creation.input_tokens"]
   end
@@ -125,6 +126,7 @@ class InstrumentationTest < Minitest::Test
     chat.ask("Hi")
 
     span = EXPORTER.finished_spans.first
+    assert_equal 195, span.attributes["gen_ai.usage.input_tokens"]
     assert_equal 75, span.attributes["gen_ai.usage.cache_read.input_tokens"]
     assert_equal 20, span.attributes["gen_ai.usage.cache_creation.input_tokens"]
   end


### PR DESCRIPTION
## Problem

The [OTel GenAI semconv](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) defines `gen_ai.usage.input_tokens` as the full model input. ruby_llm's `Message#input_tokens` for OpenAI is the cache-miss count (`prompt_tokens` minus cache reads and writes). Exporting that value as `gen_ai.usage.input_tokens` makes semconv-following backends subtract `gen_ai.usage.cache_read.input_tokens` a second time. Langfuse, for example, clamps input to 0 on cache hits and prices the non-cached input at $0.

## Fix

Add the cached counts back before export, so `gen_ai.usage.input_tokens` carries the full input per the semconv, while `cache_read` / `cache_creation` remain the cached breakdown. The `respond_to?` guards keep ruby_llm versions without the cache accessors working.

## Tests

Extended the two prompt-cache tests to pin the inclusive value: OpenAI (100 = 25 miss + 75 cached) and Anthropic (195 = 100 + 75 + 20; Anthropic's `input_tokens` is already cache-exclusive).